### PR TITLE
Fix load error and the byte-compile warning

### DIFF
--- a/helm-tail.el
+++ b/helm-tail.el
@@ -32,6 +32,7 @@
 
 ;;; Code:
 
+(require 'helm)
 (require 'helm-source)
 ;; For helm-source-kill-ring
 ;; (require 'helm-ring)


### PR DESCRIPTION
Loading error

```
Load error for /home/syohei/tmp/helm-tail/helm-tail.el:
(void-variable helm-map)
```

Byte compile warning

```
helm-tail.el:124:4: Warning: the function ‘helm’ is not known to be defined.
```